### PR TITLE
chore: vt-linux CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @getoutreach/vt-linux


### PR DESCRIPTION
Adds @getoutreach/vt-linux as the CODEOWNERS of this repository to make
it easier for reviews to happen.
