### PR TITLE
docs: add replacement notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Repository has been replaced by https://github.com/jaredallard/asahi-overlay/.
+
+**NOTE**: As of 2024/02/08, this repository has been replaced by https://github.com/jaredallard/asahi-overlay/.
+
+---
+
 # overlay
 
 A general purpose overlay maintained by Outreach.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Repository has been replaced by https://github.com/jaredallard/asahi-overlay/.
 
-**NOTE**: As of 2024/02/08, this repository has been replaced by https://github.com/jaredallard/asahi-overlay/.
+> [!IMPORTANT]
+> As of 2024/02/08, this repository has been replaced by https://github.com/jaredallard/asahi-overlay/.
 
 ---
 


### PR DESCRIPTION
Adds a notice to the README of this repository's state, pointing users to my fork[^1] instead. I'd suggest after merging this that the repository be archived.

[^1]: https://github.com/jaredallard/asahi-overlay/